### PR TITLE
Fix code scanning alert no. 3: Uncontrolled command line

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from flask_jwt_extended import JWTManager, create_access_token, jwt_required, ge
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
 import datetime
+import subprocess
 
 app = Flask(__name__)
 CORS(app)
@@ -390,7 +391,7 @@ def set_pin_advanced(pin_number):
                 drive_strength = data['drive_strength']
                 if drive_strength not in ['2mA', '4mA', '8mA', '12mA', '16mA']:
                     return jsonify({'error': 'Invalid drive strength'}), 400
-                os.system(f'raspi-gpio set {pin_number} dl {drive_strength[:-2]}')
+                subprocess.run(['raspi-gpio', 'set', str(pin_number), 'dl', drive_strength[:-2]], check=True)
                 pin_states[pin_number]['drive_strength'] = drive_strength
 
             # Set slew rate (FAST/SLOW)
@@ -398,13 +399,13 @@ def set_pin_advanced(pin_number):
                 slew_rate = data['slew_rate']
                 if slew_rate not in ['FAST', 'SLOW']:
                     return jsonify({'error': 'Invalid slew rate'}), 400
-                os.system(f'raspi-gpio set {pin_number} sl {"1" if slew_rate == "FAST" else "0"}')
+                subprocess.run(['raspi-gpio', 'set', str(pin_number), 'sl', '1' if slew_rate == 'FAST' else '0'], check=True)
                 pin_states[pin_number]['slew_rate'] = slew_rate
 
             # Set hysteresis (ON/OFF)
             if 'hysteresis' in data:
                 hysteresis = bool(data['hysteresis'])
-                os.system(f'raspi-gpio set {pin_number} hy {"1" if hysteresis else "0"}')
+                subprocess.run(['raspi-gpio', 'set', str(pin_number), 'hy', '1' if hysteresis else '0'], check=True)
                 pin_states[pin_number]['hysteresis'] = hysteresis
 
         except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/woodmurderedhat/raspberry-gpio-controller/security/code-scanning/3](https://github.com/woodmurderedhat/raspberry-gpio-controller/security/code-scanning/3)

To fix the problem, we should avoid using `os.system` with untrusted input. Instead, we can use the `subprocess` module, which provides more control over how commands are executed. Specifically, we can use `subprocess.run` with a list of arguments to avoid shell injection vulnerabilities. Additionally, we should validate the `pin_number` and other inputs to ensure they are within expected ranges or values.

1. Replace `os.system` calls with `subprocess.run` calls.
2. Validate the `pin_number` and other inputs before using them in the command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
